### PR TITLE
Fix warnings and errors on Windows/MSVC

### DIFF
--- a/array.h
+++ b/array.h
@@ -1,6 +1,8 @@
 #ifndef BDD_ARRAY_H
 #define BDD_ARRAY_H
 
+#include "stdlib.h"
+
 typedef struct _bdd_array {
     void ** values;
     size_t capacity;
@@ -9,6 +11,10 @@ typedef struct _bdd_array {
 
 _bdd_array* _bdd_array_create() {
     _bdd_array *arr = malloc(sizeof(_bdd_array));
+    if (!arr) {
+        perror("malloc(array)");
+        abort();
+    }
     arr->capacity = 4;
     arr->size = 0;
     arr->values = calloc(arr->capacity, sizeof(void *));
@@ -18,7 +24,12 @@ _bdd_array* _bdd_array_create() {
 _bdd_array* _bdd_array_push(_bdd_array* arr, void *item) {
     if (arr->size == arr->capacity) {
         arr->capacity *= 2;
-        arr->values = realloc(arr->values, sizeof(void *) * arr->capacity);
+        void *v = realloc(arr->values, sizeof(void *) * arr->capacity);
+        if (!v) {
+            perror("realloc(array)");
+            abort();
+        }
+        arr->values = v;
     }
     arr->values[arr->size++] = item;
     return arr;


### PR DESCRIPTION
- Provide implementation of strlcat
- Address alloc function warnings by checking for NULL returns
- Fix error C2036 by casting void* to char* before increment