### PR TITLE
Use == instead of = in check example

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ statement, or contain a code block (a list of statements):
 
 spec('statements') {
     it("should not do anything");
-    it("should be in short form") check(1 + 1 = 2);
+    it("should be in short form") check(1 + 1 == 2);
     it("should have a code block") {
-        check(1 + 1 = 2);
+        check(1 + 1 == 2);
     }
 }
 ```


### PR DESCRIPTION
I know this is a bit pedantic, so I won't be offended if you don't want to change this. However, since the context here is C, it was bugging me that the example used `=` while the context implied that the intent was comparison not assignment. :)