### PR TITLE
Run after_each() hooks in the described LIFO order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,6 @@ add_executable(array_test ${ARRAY_SOURCES})
 
 set(DYNAMIC_TEST_SOURCES dynamic-test.c bdd-for-c.h array.h)
 add_executable(dynamic_test ${DYNAMIC_TEST_SOURCES})
+
+set(BEFORE_AFTER_SOURCES before-after.c bdd-for-c.h)
+add_executable(before_after ${BEFORE_AFTER_SOURCES})

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -229,7 +229,8 @@ void __bdd_node_flatten_internal__(
         __bdd_array_push__(steps, __bdd_test_step_create__(level, node));
 
         for (size_t listIndex = 0; listIndex < after_each_lists->size; ++listIndex) {
-            __bdd_array__ *list = after_each_lists->values[listIndex];
+            size_t reverseListIndex = after_each_lists->size - listIndex - 1;
+            __bdd_array__ *list = after_each_lists->values[reverseListIndex];
             for (size_t i = 0; i < list->size; ++i) {
                 __bdd_array_push__(steps, __bdd_test_step_create__(level, list->values[i]));
             }

--- a/before-after.c
+++ b/before-after.c
@@ -1,0 +1,92 @@
+#include <stdlib.h>
+#include "bdd-for-c.h"
+
+spec("before and after hooks") {
+    describe("call order") {
+        static struct {
+            int before_at, before_each_at, after_at, after_each_at;
+        } outer1, outer2, inner1, inner2;
+        static int it_at, call_order = 1;
+
+        describe("outer") {
+            before()            outer1.before_at = call_order++;
+            after()             outer1.after_at = call_order++;
+            before_each()       outer1.before_each_at = call_order++;
+            after_each()        outer1.after_each_at = call_order++;
+
+            describe("inner") {
+                before()        inner1.before_at = call_order++;
+                after()         inner1.after_at = call_order++;
+                before_each()   inner1.before_each_at = call_order++;
+                after_each()    inner1.after_each_at = call_order++;
+
+                it("should be run") it_at = call_order++;
+
+                before()        inner2.before_at = call_order++;
+                after()         inner2.after_at = call_order++;
+                before_each()   inner2.before_each_at = call_order++;
+                after_each()    inner2.after_each_at = call_order++;
+            }
+
+            before()            outer2.before_at = call_order++;
+            after()             outer2.after_at = call_order++;
+            before_each()       outer2.before_each_at = call_order++;
+            after_each()        outer2.after_each_at = call_order++;
+        }
+
+        // Note: these tests depends on the one test above having been run. 
+        it("should execute 17 steps")
+            check(call_order - 1 == 17, "got: %d", call_order - 1);
+
+        it("1. outer before 1")
+            check(1 == outer1.before_at, "got: %d", outer1.before_at);
+
+        it("2. outer before 2")
+            check(2 == outer2.before_at, "got: %d", outer2.before_at);
+
+        it("3. inner before 1")
+            check(3 == inner1.before_at, "got: %d", inner1.before_at);
+
+        it("4. inner before 2")
+            check(4 == inner2.before_at, "got: %d", inner2.before_at);
+
+        it("5. outer before each 1")
+            check(5 == outer1.before_each_at, "got: %d", outer1.before_each_at);
+
+        it("6. outer before each 2")
+            check(6 == outer2.before_each_at, "got: %d", outer2.before_each_at);
+
+        it("7. inner before each 1")
+            check(7 == inner1.before_each_at, "got: %d", inner1.before_each_at);
+
+        it("8. inner before each 2")
+            check(8 == inner2.before_each_at, "got: %d", inner2.before_each_at);
+
+        it("9. it")
+            check(9 == it_at == 1, "got: %d", it_at);
+
+        it("10. inner after each 1")
+            check(10 == inner1.after_each_at, "got: %d", inner1.after_each_at);
+
+        it("11. inner after each 2")
+            check(11 == inner2.after_each_at, "got: %d", inner2.after_each_at);
+
+        it("12. outer after each 1")
+            check(12 == outer1.after_each_at, "got: %d", outer1.after_each_at);
+
+        it("13. outer after each 2")
+            check(13 == outer2.after_each_at, "got: %d", outer2.after_each_at);
+
+        it("14. inner after 1")
+            check(14 == inner1.after_at, "got: %d", inner1.after_at);
+
+        it("15. inner after 2")
+            check(15 == inner2.after_at, "got: %d", inner2.after_at);
+
+        it("16. outer after 1")
+            check(16 == outer1.after_at, "got: %d", outer1.after_at);
+
+        it("17. outer after 2")
+            check(17 == outer2.after_at, "got: %d", outer2.after_at);
+    }
+}


### PR DESCRIPTION
My test crashed and I noticed that `after_each()` hooks in nested `describe()` blocks are run in FIFO order. In other words, first the top-level `after_each()` hooks were run, then the ones in the nested `describe()`, then the next nested `describe()`, etc.

This was unexpected behavior. Typically these hooks are executed on the same level so that data structures that are allocated on one level in a `before_each()` can be freed on the same level in an `after_each()`, before the objects in the outer scope are freed.

This PR changes the order in which `after_each()` hooks are run so that the inner-most hooks are executed first and the outer most last.