### PR TITLE
Fix memory leaks

### DIFF
--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -346,7 +346,15 @@ bool __bdd_enter_node__(__bdd_config_type__ *config, __bdd_node_type__ type, ptr
         return false;
     }
 
+    if (config->id >= config->nodes->size) {
+        fprintf(stderr, "non-deterministic spec\n");
+        abort();
+    }
     __bdd_node__ *node = config->nodes->values[config->id];
+    if (node->type != type || strcmp(node->name, name) != 0) {
+        fprintf(stderr, "non-deterministic spec\n");
+        abort();
+    }
     free(name);
 
     __bdd_test_step__ *step = config->current_test;

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -61,6 +61,7 @@ SOFTWARE.
 #define __BDD_COLOR_RED__         "\x1B[31m"             /* Red */
 #define __BDD_COLOR_GREEN__       "\x1B[32m"             /* Green */
 #define __BDD_COLOR_BOLD__        "\x1B[1m"              /* Bold White */
+#define __BDD_COLOR_MAGENTA__     "\x1B[35m"             /* Magenta */
 
 size_t __bdd_strlcat__(char* dst, const char* src, size_t size)
 {
@@ -356,6 +357,19 @@ bool __bdd_enter_node__(__bdd_config_type__ *config, __bdd_node_type__ type, ptr
     } else {
         config->id = node->next_node_id;
     }
+#if defined(BDD_PRINT_TRACE)
+    fprintf(
+        stderr,
+        "%s%d %s [%d, %d) %s%s\n",
+        config->use_color ? __BDD_COLOR_MAGENTA__ : "",
+        config->current_test->id,
+        should_enter ? ">" : "|",
+        node->id,
+        node->next_node_id,
+        node->name,
+        config->use_color ? __BDD_COLOR_RESET__ : ""
+    );
+#endif
     return should_enter;
 }
 

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -593,16 +593,21 @@ void __bdd_snprintf__(char *buffer, size_t bufflen, const char *fmt, const char 
 #define __BDD_STRING__(x) __BDD_STRING_HELPER__(x)
 #define __STRING__LINE__ __BDD_STRING__(__LINE__)
 
+#define __BDD_FMT_COLOR__ __BDD_COLOR_RED__ "Check failed:" __BDD_COLOR_RESET__ " %s"
+#define __BDD_FMT_PLAIN__ "Check failed: %s"
+
 #define __BDD_CHECK__(condition, ...) if (!(condition))\
 {\
     char *message = __bdd_format__(__VA_ARGS__);\
-    const char *fmt = __bdd_config__->use_color ?\
-        (__BDD_COLOR_RED__ "Check failed:" __BDD_COLOR_RESET__ " %s" ) :\
-        "Check failed: %s";\
+    const char *fmt = __bdd_config__->use_color ? __BDD_FMT_COLOR__ : __BDD_FMT_PLAIN__;\
     __bdd_config__->location = "at " __FILE__ ":" __STRING__LINE__;\
     size_t bufflen = strlen(fmt) + strlen(message) + 1;\
     __bdd_config__->error = calloc(bufflen, sizeof(char));\
-    __bdd_snprintf__(__bdd_config__->error, bufflen, fmt, message);\
+    if (__bdd_config__->use_color) {\
+      snprintf(__bdd_config__->error, bufflen, __BDD_FMT_COLOR__, message);\
+    } else {\
+      snprintf(__bdd_config__->error, bufflen, __BDD_FMT_PLAIN__, message);\
+    }\
     free(message);\
     return;\
 }

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -253,14 +253,18 @@ void __bdd_node_flatten_internal__(
     }
 }
 
-__bdd_array__ *__bdd_node_flatten__(__bdd_node__ *node, __bdd_array__ *names) {
+__bdd_array__ *__bdd_node_flatten__(__bdd_node__ *node, __bdd_array__ *steps) {
     if (node == NULL) {
-        return names;
+        return steps;
     }
 
-    __bdd_node_flatten_internal__(0, node, names, __bdd_array_create__(), __bdd_array_create__());
+    __bdd_array__ *before_each_lists = __bdd_array_create__();
+    __bdd_array__ *after_each_lists = __bdd_array_create__();
+    __bdd_node_flatten_internal__(0, node, steps, before_each_lists, after_each_lists);
+    __bdd_array_free__(before_each_lists);
+    __bdd_array_free__(after_each_lists);
 
-    return names;
+    return steps;
 }
 
 void __bdd_node_free__(__bdd_node__ *n);

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -273,6 +273,12 @@ char *__bdd_spec_name__;
 void __bdd_test_main__(__bdd_config_type__ *__bdd_config__);
 char *__bdd_vformat__(const char *format, va_list va);
 
+void __bdd_indent__(FILE *fp, size_t level) {
+    for (size_t i = 0; i < level; ++i) {
+        fprintf(fp, "  ");
+    }
+}
+
 bool __bdd_enter_node__(__bdd_config_type__ *config, __bdd_node_type__ type, ptrdiff_t list_offset, char *fmt, ...) {
     va_list va;
     va_start(va, fmt);
@@ -340,9 +346,7 @@ void __bdd_run__(__bdd_config_type__ *config) {
     __bdd_test_step__ *step = config->current_test;
 
     if (step->type == __BDD_NODE_GROUP__ && !config->use_tap) {
-        for (size_t i = 0; i < step->level; ++i) {
-            printf("  ");
-        }
+        __bdd_indent__(stdout, step->level);
         printf(
             "%s%s%s\n",
             config->use_color ? __BDD_COLOR_BOLD__ : "",
@@ -368,9 +372,7 @@ void __bdd_run__(__bdd_config_type__ *config) {
                     printf("ok %zu - %s\n", config->test_tap_index, step->name);
                 }
             } else {
-                for (size_t i = 0; i < step->level; ++i) {
-                    printf("  ");
-                }
+                __bdd_indent__(stdout, step->level);
                 printf(
                     "%s %s(OK)%s\n", step->name,
                     config->use_color ? __BDD_COLOR_GREEN__ : "",
@@ -386,21 +388,15 @@ void __bdd_run__(__bdd_config_type__ *config) {
                 printf("not ok %zu - %s\n", config->test_tap_index, step->name);
             }
         } else {
-            for (size_t i = 0; i < step->level; ++i) {
-                printf("  ");
-            }
+            __bdd_indent__(stdout, step->level);
             printf(
                 "%s %s(FAIL)%s\n", step->name,
                 config->use_color ? __BDD_COLOR_RED__ : "",
                 config->use_color ? __BDD_COLOR_RESET__ : ""
             );
-            for (size_t i = 0; i < step->level + 1; ++i) {
-                printf("  ");
-            }
+            __bdd_indent__(stdout, step->level + 1);
             printf("%s\n", config->error);
-            for (size_t i = 0; i < step->level + 2; ++i) {
-                printf("  ");
-            }
+            __bdd_indent__(stdout, step->level + 2);
             printf("%s\n", config->location);
         }
         free(config->error);

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -390,7 +390,6 @@ void __bdd_exit_node__(__bdd_config_type__ *config) {
 
 void __bdd_run__(__bdd_config_type__ *config) {
     __bdd_test_step__ *step = config->current_test;
-    __bdd_test_main__(config);
 
     if (step->type == __BDD_NODE_GROUP__ && !config->use_tap) {
         for (size_t i = 0; i < step->level; ++i) {
@@ -402,7 +401,10 @@ void __bdd_run__(__bdd_config_type__ *config) {
             step->name,
             config->use_color ? __BDD_COLOR_RESET__ : ""
         );
+        return;
     }
+
+    __bdd_test_main__(config);
 
     if (step->type != __BDD_NODE_TEST__) {
         return;

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -207,7 +207,7 @@ void __bdd_node_flatten_internal__(
     __bdd_array_push__(steps, __bdd_test_step_create__(level, node));
 
     for (size_t i = 0; i < node->list_before->size; ++i) {
-        __bdd_array_push__(steps, __bdd_test_step_create__(level, node->list_before->values[i]));
+        __bdd_array_push__(steps, __bdd_test_step_create__(level + 1, node->list_before->values[i]));
     }
 
     __bdd_array_push__(before_each_lists, node->list_before_each);
@@ -221,7 +221,7 @@ void __bdd_node_flatten_internal__(
     __bdd_array_pop__(after_each_lists);
 
     for (size_t i = 0; i < node->list_after->size; ++i) {
-        __bdd_array_push__(steps, __bdd_test_step_create__(level, node->list_after->values[i]));
+        __bdd_array_push__(steps, __bdd_test_step_create__(level + 1, node->list_after->values[i]));
     }
 }
 
@@ -320,17 +320,17 @@ bool __bdd_enter_node__(__bdd_config_type__ *config, __bdd_node_type__ type, ptr
         config->id = node->next_node_id;
     }
 #if defined(BDD_PRINT_TRACE)
-    fprintf(
-        stderr,
-        "%s%d %s [%d, %d) %s%s\n",
-        config->use_color ? __BDD_COLOR_MAGENTA__ : "",
-        config->current_test->id,
+    const char *color = config->use_color ? __BDD_COLOR_MAGENTA__ : "";
+    fprintf(stderr, "%s% 3d ", color, step->id);
+    __bdd_indent__(stderr, config->node_stack->size - 1 - (int)should_enter);
+    const char *reset = config->use_color ? __BDD_COLOR_RESET__ : "";
+    fprintf(stderr,
+        "%s [%d, %d) %s%s\n",
         should_enter ? ">" : "|",
         node->id,
         node->next_node_id,
         node->name,
-        config->use_color ? __BDD_COLOR_RESET__ : ""
-    );
+        reset);
 #endif
     return should_enter;
 }

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -578,17 +578,6 @@ for(\
 #define __BDD_COUNT_ARGS__(...) __BDD_PATTERN_MATCH__(__VA_ARGS__,_,_,_,_,_,_,_,_,_,ONE__)
 #define __BDD_PATTERN_MATCH__(_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,N, ...) N
 
-void __bdd_snprintf__(char *buffer, size_t bufflen, const char *fmt, const char *message) {
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4996) // _CRT_SECURE_NO_WARNINGS
-#endif
-    snprintf(buffer, bufflen, fmt, message);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-}
-
 #define __BDD_STRING_HELPER__(x) #x
 #define __BDD_STRING__(x) __BDD_STRING_HELPER__(x)
 #define __STRING__LINE__ __BDD_STRING__(__LINE__)

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -300,7 +300,7 @@ bool __bdd_enter_node__(__bdd_config_type__ *config, __bdd_node_type__ type, ptr
         return false;
     }
 
-    if (config->id >= config->nodes->size) {
+    if (config->id >= (int)config->nodes->size) {
         fprintf(stderr, "non-deterministic spec\n");
         abort();
     }

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -520,16 +520,6 @@ int main(void) {
         __bdd_run__(&config);
     }
 
-    if (config.failed_test_count > 0) {
-        if (!config.use_tap) {
-            printf(
-                "\n%zu test%s run, %zu failed.\n",
-                test_count, test_count == 1 ? "" : "s", config.failed_test_count
-            );
-        }
-        return 1;
-    }
-
     for (size_t i = 0; i < config.nodes->size; ++i) {
         __bdd_node_free__(config.nodes->values[i]);
     }
@@ -542,6 +532,15 @@ int main(void) {
     __bdd_array_free__(config.node_stack);
     __bdd_array_free__(steps);
 
+    if (config.failed_test_count > 0) {
+        if (!config.use_tap) {
+            printf(
+                "\n%zu test%s run, %zu failed.\n",
+                test_count, test_count == 1 ? "" : "s", config.failed_test_count
+            );
+        }
+        return 1;
+    }
     return 0;
 }
 
@@ -596,7 +595,7 @@ void __bdd_snprintf__(char *buffer, size_t bufflen, const char *fmt, const char 
 
 #define __BDD_CHECK__(condition, ...) if (!(condition))\
 {\
-    const char *message = __bdd_format__(__VA_ARGS__);\
+    char *message = __bdd_format__(__VA_ARGS__);\
     const char *fmt = __bdd_config__->use_color ?\
         (__BDD_COLOR_RED__ "Check failed:" __BDD_COLOR_RESET__ " %s" ) :\
         "Check failed: %s";\
@@ -604,6 +603,7 @@ void __bdd_snprintf__(char *buffer, size_t bufflen, const char *fmt, const char 
     size_t bufflen = strlen(fmt) + strlen(message) + 1;\
     __bdd_config__->error = calloc(bufflen, sizeof(char));\
     __bdd_snprintf__(__bdd_config__->error, bufflen, fmt, message);\
+    free(message);\
     return;\
 }
 

--- a/bdd-for-c.h
+++ b/bdd-for-c.h
@@ -63,34 +63,6 @@ SOFTWARE.
 #define __BDD_COLOR_BOLD__        "\x1B[1m"              /* Bold White */
 #define __BDD_COLOR_MAGENTA__     "\x1B[35m"             /* Magenta */
 
-size_t __bdd_strlcat__(char* dst, const char* src, size_t size)
-{
-    size_t len = 0;
-    size_t slen = strlen(src);
-    while (*dst && size > 0) {
-        dst++;
-        len++;
-        size--;
-    }
-    while (*src && size-- > 1) {
-        *dst++ = *src++;
-    }
-    if (size == 1 || *src == 0) {
-        *dst = 0;
-    }
-    return slen + len;
-}
-
-
-bool __bdd_same_string__(const char *str1, const char *str2) {
-    size_t str1length = strlen(str1);
-    size_t str2length = strlen(str2);
-    if (str1length != str2length) {
-        return 0;
-    }
-    return strncmp(str1, str2, str1length) == 0;
-}
-
 typedef struct __bdd_array__ {
     void **values;
     size_t capacity;
@@ -275,27 +247,6 @@ void __bdd_node_free__(__bdd_node__ *n) {
     __bdd_array_free__(n->list_after_each);
     __bdd_array_free__(n->list_children);
     free(n);
-}
-
-char *__bdd_node_names_concat__(__bdd_array__ *list, const char *delimiter) {
-    size_t result_size = 1;
-
-    for (size_t i = 0; i < list->size; ++i) {
-        result_size += strlen(((__bdd_node__ *) list->values[i])->name) + strlen(delimiter);
-    }
-
-    char *result = calloc(result_size, sizeof(char));
-    if (!result) {
-        perror("calloc(result)");
-        abort();
-    }
-
-    for (size_t i = 0; i < list->size; ++i) {
-        __bdd_strlcat__(result, ((__bdd_node__ *) list->values[i])->name, result_size);
-        __bdd_strlcat__(result, delimiter, result_size);
-    }
-
-    return result;
 }
 
 enum __bdd_run_type__ {

--- a/before-after.c
+++ b/before-after.c
@@ -63,7 +63,7 @@ spec("before and after hooks") {
             check(8 == inner2.before_each_at, "got: %d", inner2.before_each_at);
 
         it("9. it")
-            check(9 == it_at == 1, "got: %d", it_at);
+            check(9 == it_at, "got: %d", it_at);
 
         it("10. inner after each 1")
             check(10 == inner1.after_each_at, "got: %d", inner1.after_each_at);

--- a/dynamic-test.c
+++ b/dynamic-test.c
@@ -21,7 +21,7 @@ spec("dynamic tests") {
         };
 
         describe("strspn") {
-            for (int i = 0; i < ARRAY_LENGTH(strspn_cases); i++) {
+            for (size_t i = 0; i < ARRAY_LENGTH(strspn_cases); i++) {
                 const char *input = strspn_cases[i].input;
                 const char *accept = strspn_cases[i].accept;
                 size_t expected = strspn_cases[i].expected;
@@ -52,7 +52,7 @@ spec("dynamic tests") {
 
         // Similarly, describe(name) also accepts a format string. This can be
         // used when checking that several functions have a similar behavior.
-        for (int i = 0; i < ARRAY_LENGTH(copy_functions); i++)
+        for (size_t i = 0; i < ARRAY_LENGTH(copy_functions); i++)
         describe("the %s function", copy_functions[i].name) {
             it("should copy a string to a buffer") {
                 char data[] = "hello, world";
@@ -90,11 +90,11 @@ spec("dynamic tests") {
         };
 
         // It's also possible to combine the two arbitrarily
-        for (int i = 0; i < ARRAY_LENGTH(arithmetic_tests); i++)
+        for (size_t i = 0; i < ARRAY_LENGTH(arithmetic_tests); i++)
         describe("operator %s", arithmetic_tests[i].symbol) {
             int (*operator)(int, int) = arithmetic_tests[i].operator;
 
-            for (int j = 0; j < arithmetic_tests[i].count; j++) {
+            for (size_t j = 0; j < arithmetic_tests[i].count; j++) {
                 const struct expression *e = &arithmetic_tests[i].examples[j];
                 int a = e->a, b = e->b, c = e->c;
 


### PR DESCRIPTION
Hi again. Here's a PR with rather substantial changes. Maybe next time I'll create an issue first before starting work.

### Background

I noticed that, while there are places in the code where memory is freed, several allocations are not matched with deallocations. `__BDD_STEP__()` and `describe()` in particular allocates nodes and strings every time `__bdd_test_main__` is called. While I won't run out of memory, it's hard to see if my own code properly cleans up after itself when the test inherently leaks memory. I tried to find an easy way to free the memory allocations but I couldn't find a way that didn't make the code much more messy. I took a deeper dive into the code and this is what I came up with.

Here's example valgrind output on master from `example_test`:
```
HEAP SUMMARY:
    in use at exit: 20,640 bytes in 554 blocks
  total heap usage: 1,462 allocs, 908 frees, 560,207 bytes allocated
``` 

### Description

This PR changes bdd-for-c.h so that it frees all memory it allocates. It does this by only creating nodes the first time `__bdd_test_main__` is called and it avoids allocating as many temporary strings. Instead of using the name or path of the current step (since 562a039) to decide which steps to execute, each node is given a sequential ID during the initial run which is used instead. There's also an index in the config that maps from ID to the node so that the node names can be compared like before (for sanity checking) and, as a minor optimization, this also makes it possible to skip entire node groups altogether when they don't contain the current step.

There's also a new compile time option `BDD_PRINT_TRACE`. When it's defined there's a line printed to stderr for every describe/it/before/etc. statement. It mirrors the normal output to some degree, but it prints which nodes were entered/executed and which were skipped. It''s quite verbose, but is useful when debugging this feature/bdd-for-c.h itself. It might also be useful to users who have buggy tests or want to know how bdd-for-c works under the hood. A snippet output of example_test looks like this:
```
some feature
  9 | [0, 1) after_each
  9 | [1, 4) sub-feature 1
  9 | [4, 8) sub-feature 2
  9 | [8, 9) before_each
  9 > [9, 10) before
  sub-feature 1
  8 | [0, 1) after_each
  8 | [1, 4) sub-feature 1
  8 | [4, 8) sub-feature 2
  8 > [8, 9) before_each
  8 | [9, 10) before
```
The first number on each line is the ID of the current step to be executed. Before the node's name is the range of node IDs, the minimum being the ID of the node itself. If a node was passed by there's a `|` character and the ones that are entered/executed are marked iwth a `>`. For instance, the trace shows that the `describe("sub-feature 1")`, which has node ID 1 and descendants with IDs less than 4, was not entered.

### Change summary

- Replace `__BDD_STEP__()`/`describe()` with `__BDD_NODE__`/`__bdd_enter_node__()`/`__bdd_exit_node__()`
- Replace `node.prefix`/`step.full_name` with numeric IDs
- Remove now unused string utility functions
- Add list of all nodes to `__bdd_config_type__`

### Memory management details

- Nodes take ownership of their names, and are responsible for freeing their name and their lists, but no child nodes
- Steps are own no resources
- All nodes and steps are freed at the end of `main()`

### Open questions

Is it okay to remove the prefix/full_name fields, or are they planned to be used for something else?